### PR TITLE
test: Add unit tests for service and controller with JaCoCo coverage

### DIFF
--- a/src/test/java/org/taller01/transactionms/controller/TransactionControllerTest.java
+++ b/src/test/java/org/taller01/transactionms/controller/TransactionControllerTest.java
@@ -1,0 +1,197 @@
+package org.taller01.transactionms.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.taller01.transactionms.domain.Transaction;
+import org.taller01.transactionms.domain.TransactionStatus;
+import org.taller01.transactionms.domain.TransactionType;
+import org.taller01.transactionms.dto.request.DepositRequest;
+import org.taller01.transactionms.dto.request.TransferRequest;
+import org.taller01.transactionms.dto.request.WithdrawRequest;
+import org.taller01.transactionms.dto.response.TransactionResponse;
+import org.taller01.transactionms.service.TransactionService;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@WebFluxTest(controllers = TransactionController.class)
+class TransactionControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private TransactionService service;
+
+    // ------- helpers without unused parameters (no inspection warnings) -------
+    private Transaction baseTx(TransactionType type) {
+        return Transaction.builder()
+                .id("T1")
+                .type(type)
+                .status(TransactionStatus.SUCCESS)
+                .fromAccountId("A1")
+                .toAccountId("A2")
+                .amount(new BigDecimal("100"))
+                .message("ok")
+                .createdAt(Instant.now())
+                .build();
+    }
+    private Transaction txDeposit()   { return baseTx(TransactionType.DEPOSIT); }
+    private Transaction txWithdrawal(){ return baseTx(TransactionType.WITHDRAWAL); }
+    private Transaction txTransfer()  { return baseTx(TransactionType.TRANSFER); }
+
+    // --------------------------
+    // POST /transacciones/deposito
+    // --------------------------
+    @Nested @DisplayName("POST /transacciones/deposito")
+    class Deposit {
+
+        @Test
+        @DisplayName("returns 200 with transaction payload")
+        void deposit_success_200() {
+            given(service.deposit(any(DepositRequest.class)))
+                    .willReturn(Mono.just(txDeposit()));
+
+            webTestClient.post()
+                    .uri("/transacciones/deposito")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("{\"accountId\":\"A1\",\"amount\":100}")
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+                    .expectBody()
+                    .jsonPath("$.id").isEqualTo("T1")
+                    .jsonPath("$.type").isEqualTo("DEPOSIT")
+                    .jsonPath("$.status").isEqualTo("SUCCESS")
+                    .jsonPath("$.amount").isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("returns 400 when body is missing")
+        void deposit_bad_request_400_when_body_empty() {
+            webTestClient.post()
+                    .uri("/transacciones/deposito")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .exchange()
+                    .expectStatus().isBadRequest();
+        }
+    }
+
+    // ------------------------
+    // POST /transacciones/retiro
+    // ------------------------
+    @Nested @DisplayName("POST /transacciones/retiro")
+    class Withdraw {
+
+        @Test
+        @DisplayName("returns 200 with transaction payload")
+        void withdraw_success_200() {
+            given(service.withdraw(any(WithdrawRequest.class)))
+                    .willReturn(Mono.just(txWithdrawal()));
+
+            webTestClient.post()
+                    .uri("/transacciones/retiro")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("{\"accountId\":\"A1\",\"amount\":50}")
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+                    .expectBody()
+                    .jsonPath("$.type").isEqualTo("WITHDRAWAL")
+                    .jsonPath("$.status").isEqualTo("SUCCESS")
+                    .jsonPath("$.fromAccountId").isEqualTo("A1");
+        }
+
+        @Test
+        @DisplayName("returns 400 when body is missing")
+        void withdraw_bad_request_400_when_body_empty() {
+            webTestClient.post()
+                    .uri("/transacciones/retiro")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .exchange()
+                    .expectStatus().isBadRequest();
+        }
+    }
+
+    // --------------------------------
+    // POST /transacciones/transferencia
+    // --------------------------------
+    @Nested @DisplayName("POST /transacciones/transferencia")
+    class Transfer {
+
+        @Test
+        @DisplayName("returns 200 with transaction payload")
+        void transfer_success_200() {
+            given(service.transfer(any(TransferRequest.class)))
+                    .willReturn(Mono.just(txTransfer()));
+
+            webTestClient.post()
+                    .uri("/transacciones/transferencia")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("{\"fromAccountId\":\"A1\",\"toAccountId\":\"A2\",\"amount\":70}")
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+                    .expectBody()
+                    .jsonPath("$.type").isEqualTo("TRANSFER")
+                    .jsonPath("$.status").isEqualTo("SUCCESS")
+                    .jsonPath("$.fromAccountId").isEqualTo("A1")
+                    .jsonPath("$.toAccountId").isEqualTo("A2");
+        }
+
+        @Test
+        @DisplayName("returns 400 when body is missing")
+        void transfer_bad_request_400_when_body_empty() {
+            webTestClient.post()
+                    .uri("/transacciones/transferencia")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .exchange()
+                    .expectStatus().isBadRequest();
+        }
+    }
+
+    // -----------------------------
+    // GET /transacciones/historial
+    // -----------------------------
+    @Nested @DisplayName("GET /transacciones/historial")
+    class History {
+
+        @Test
+        @DisplayName("returns 200 with list payload")
+        void history_success_200() {
+            TransactionResponse tr = TransactionResponse.from(txDeposit());
+            given(service.getHistory(eq("A1"))).willReturn(Flux.just(tr));
+
+            webTestClient.get()
+                    .uri("/transacciones/historial?cuentaId=A1")
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+                    .expectBody()
+                    .jsonPath("$[0].id").isEqualTo("T1")
+                    .jsonPath("$[0].type").isEqualTo("DEPOSIT")
+                    .jsonPath("$[0].status").isEqualTo("SUCCESS");
+        }
+
+        @Test
+        @DisplayName("returns 400 when cuentaId is missing")
+        void history_bad_request_400_when_param_missing() {
+            webTestClient.get()
+                    .uri("/transacciones/historial")
+                    .exchange()
+                    .expectStatus().isBadRequest();
+        }
+    }
+}

--- a/src/test/java/org/taller01/transactionms/service/TransactionServiceTest.java
+++ b/src/test/java/org/taller01/transactionms/service/TransactionServiceTest.java
@@ -1,0 +1,251 @@
+package org.taller01.transactionms.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.taller01.transactionms.domain.Transaction;
+import org.taller01.transactionms.domain.TransactionStatus;
+import org.taller01.transactionms.domain.TransactionType;
+import org.taller01.transactionms.dto.request.DepositRequest;
+import org.taller01.transactionms.dto.request.TransferRequest;
+import org.taller01.transactionms.dto.request.WithdrawRequest;
+import org.taller01.transactionms.repository.TransactionRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TransactionServiceTest {
+
+    private TransactionRepository repo;   // mock
+    private WebClient webClient;          // real con exchange stub
+    private TransactionService service;
+
+    private DepositRequest depositReq;
+    private WithdrawRequest withdrawReq;
+    private TransferRequest transferReq;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(TransactionRepository.class);
+        depositReq  = new DepositRequest("A1", new BigDecimal("100.00"));
+        withdrawReq = new WithdrawRequest("A1", new BigDecimal("50.00"));
+        transferReq = new TransferRequest("A1", "A2", new BigDecimal("70.00"));
+    }
+
+    /* -------------------- WebClients stub (sin parámetros constantes) -------------------- */
+
+    /** POST (depósito/retiro) -> 200 OK */
+    private WebClient wcDepositWithdrawOk() {
+        ExchangeFunction fx = (ClientRequest req) -> {
+            if (req.method() == HttpMethod.POST) {
+                return Mono.just(ClientResponse.create(HttpStatus.OK).build());
+            }
+            return Mono.just(ClientResponse.create(HttpStatus.NOT_FOUND).build());
+        };
+        return WebClient.builder().exchangeFunction(fx).build();
+    }
+
+    /** POST (depósito/retiro) -> 409 CONFLICT (falla) */
+    private WebClient wcDepositWithdrawConflict() {
+        ExchangeFunction fx = (ClientRequest req) -> {
+            if (req.method() == HttpMethod.POST) {
+                return Mono.just(ClientResponse.create(HttpStatus.CONFLICT).build());
+            }
+            return Mono.just(ClientResponse.create(HttpStatus.NOT_FOUND).build());
+        };
+        return WebClient.builder().exchangeFunction(fx).build();
+    }
+
+    /** Transferencia: GET /cuentas/{id} devuelve balance; POSTs -> 200 OK. */
+    private WebClient wcTransferOk(BigDecimal fromBalance) {
+        ExchangeFunction fx = (ClientRequest req) -> {
+            URI u = req.url();
+            if (req.method() == HttpMethod.GET && u.getPath().startsWith("/cuentas/")) {
+                boolean isFrom = u.getPath().endsWith("/" + transferReq.fromAccountId());
+                String json = "{\"balance\":" + (isFrom ? fromBalance : "100000") + "}";
+                return Mono.just(
+                        ClientResponse.create(HttpStatus.OK)
+                                .header("Content-Type", "application/json")
+                                .body(json)
+                                .build()
+                );
+            }
+            if (req.method() == HttpMethod.POST && (u.getPath().contains("/retiro") || u.getPath().contains("/deposito"))) {
+                return Mono.just(ClientResponse.create(HttpStatus.OK).build());
+            }
+            return Mono.just(ClientResponse.create(HttpStatus.NOT_FOUND).build());
+        };
+        return WebClient.builder().exchangeFunction(fx).build();
+    }
+
+    /* ---------------------------------------- TESTS ---------------------------------------- */
+
+    @Nested @DisplayName("deposit()")
+    class Deposit {
+        @Test @DisplayName("SUCCESS cuando AccountMS responde 200")
+        void deposit_success() {
+            webClient = wcDepositWithdrawOk();
+            service = new TransactionService(repo, webClient);
+
+            when(repo.save(any(Transaction.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+            StepVerifier.create(service.deposit(depositReq))
+                    .assertNext(tx -> {
+                        assert tx.getType() == TransactionType.DEPOSIT;
+                        assert tx.getStatus() == TransactionStatus.SUCCESS;
+                        assert "A1".equals(tx.getToAccountId());
+                        assert tx.getAmount().compareTo(new BigDecimal("100.00")) == 0;
+                        assert tx.getCreatedAt() != null;
+                    })
+                    .verifyComplete();
+        }
+
+        @Test @DisplayName("FAILED cuando AccountMS responde 409/5xx")
+        void deposit_failed() {
+            webClient = wcDepositWithdrawConflict();
+            service = new TransactionService(repo, webClient);
+
+            when(repo.save(any(Transaction.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+            StepVerifier.create(service.deposit(depositReq))
+                    .assertNext(tx -> {
+                        assert tx.getType() == TransactionType.DEPOSIT;
+                        assert tx.getStatus() == TransactionStatus.FAILED;
+                        assert tx.getMessage() != null && !tx.getMessage().isBlank();
+                    })
+                    .verifyComplete();
+        }
+    }
+
+    @Nested @DisplayName("withdraw()")
+    class Withdraw {
+        @Test @DisplayName("SUCCESS cuando AccountMS responde 200")
+        void withdraw_success() {
+            webClient = wcDepositWithdrawOk();
+            service = new TransactionService(repo, webClient);
+
+            when(repo.save(any(Transaction.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+            StepVerifier.create(service.withdraw(withdrawReq))
+                    .assertNext(tx -> {
+                        assert tx.getType() == TransactionType.WITHDRAWAL;
+                        assert tx.getStatus() == TransactionStatus.SUCCESS;
+                        assert "A1".equals(tx.getFromAccountId());
+                    })
+                    .verifyComplete();
+        }
+
+        @Test @DisplayName("FAILED cuando AccountMS responde 409/5xx")
+        void withdraw_failed() {
+            webClient = wcDepositWithdrawConflict();
+            service = new TransactionService(repo, webClient);
+
+            when(repo.save(any(Transaction.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+            StepVerifier.create(service.withdraw(withdrawReq))
+                    .assertNext(tx -> {
+                        assert tx.getType() == TransactionType.WITHDRAWAL;
+                        assert tx.getStatus() == TransactionStatus.FAILED;
+                        assert tx.getMessage() != null && !tx.getMessage().isBlank();
+                    })
+                    .verifyComplete();
+        }
+    }
+
+    @Nested @DisplayName("transfer()")
+    class Transfer {
+        @Test @DisplayName("SUCCESS con saldo suficiente y POSTs 200")
+        void transfer_success() {
+            webClient = wcTransferOk(new BigDecimal("1000.00"));
+            service = new TransactionService(repo, webClient);
+
+            when(repo.save(any(Transaction.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+            StepVerifier.create(service.transfer(transferReq))
+                    .assertNext(tx -> {
+                        assert tx.getType() == TransactionType.TRANSFER;
+                        assert tx.getStatus() == TransactionStatus.SUCCESS;
+                        assert "A1".equals(tx.getFromAccountId());
+                        assert "A2".equals(tx.getToAccountId());
+                    })
+                    .verifyComplete();
+        }
+
+        @Test @DisplayName("FAILED cuando fromAccount == toAccount")
+        void transfer_same_account_failed() {
+            service = new TransactionService(repo, wcDepositWithdrawOk());
+            TransferRequest bad = new TransferRequest("A1", "A1", new BigDecimal("10"));
+
+            when(repo.save(any(Transaction.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+            StepVerifier.create(service.transfer(bad))
+                    .assertNext(tx -> {
+                        assert tx.getType() == TransactionType.TRANSFER;
+                        assert tx.getStatus() == TransactionStatus.FAILED;
+                        assert tx.getMessage().toLowerCase().contains("misma cuenta");
+                    })
+                    .verifyComplete();
+        }
+
+        @Test @DisplayName("FAILED cuando saldo insuficiente en cuenta origen")
+        void transfer_insufficient_balance_failed() {
+            // GET devolverá balance bajo; el flujo falla antes de intentar POSTs
+            webClient = wcTransferOk(new BigDecimal("20.00"));
+            service = new TransactionService(repo, webClient);
+
+            when(repo.save(any(Transaction.class))).thenAnswer(inv -> Mono.just(inv.getArgument(0)));
+
+            StepVerifier.create(service.transfer(transferReq))
+                    .assertNext(tx -> {
+                        assert tx.getType() == TransactionType.TRANSFER;
+                        assert tx.getStatus() == TransactionStatus.FAILED;
+                        assert tx.getMessage().toLowerCase().contains("saldo insuficiente");
+                    })
+                    .verifyComplete();
+        }
+    }
+
+    @Nested @DisplayName("getHistory()")
+    class History {
+        @Test @DisplayName("mapea repo -> TransactionResponse")
+        void history_maps_to_response() {
+            Transaction sample = Transaction.builder()
+                    .id("T1")
+                    .type(TransactionType.DEPOSIT)
+                    .status(TransactionStatus.SUCCESS)
+                    .fromAccountId(null)
+                    .toAccountId("A1")
+                    .amount(new BigDecimal("10"))
+                    .createdAt(Instant.now())
+                    .message("ok")
+                    .build();
+
+            when(repo.findByFromAccountIdOrToAccountId("A1", "A1"))
+                    .thenReturn(Flux.just(sample));
+
+            service = new TransactionService(repo, wcDepositWithdrawOk());
+
+            StepVerifier.create(service.getHistory("A1"))
+                    .assertNext(resp -> {
+                        assert resp != null;
+                        assert "T1".equals(resp.getId());
+                    })
+                    .verifyComplete();
+        }
+    }
+}


### PR DESCRIPTION
This PR includes:

- Unit test for TransactionService and TransactionController using Mockito.
- JaCoCo plugin configuration
- Coverage report generation

All tests pass and coverage is visible in `target/site/jacoco/index.html`.
